### PR TITLE
Prevent the player from playing after getting an error

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -643,7 +643,7 @@ class MusicBot(discord.Client):
         if 'channel' in entry.meta:
             await self.safe_send_message(
                 entry.meta['channel'],
-                "```\nError from FFmpeg:\n{}\n```".format(ex)
+                "```\nError while playing:\n{}\n```".format(ex)
             )
         else:
             log.exception("Player error", exc_info=ex)
@@ -1971,7 +1971,8 @@ class MusicBot(discord.Client):
         if player.is_paused:
             player.resume()
             return Response(self.str.get('cmd-resume-reply', 'Resumed music in `{0.name}`').format(player.voice_client.channel), delete_after=15)
-
+        elif player.is_stopped and player.playlist:
+            player.play()
         else:
             raise exceptions.CommandError(self.str.get('cmd-resume-none', 'Player is not paused.'), expire_in=30)
 

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -206,10 +206,17 @@ class MusicPlayer(EventEmitter, Serializable):
         self._current_entry = None
         self._source = None
 
+        if error:
+            self.stop()
+            self.emit('error', player=self, entry=entry, ex=error)
+            return
+
         if self._stderr_future.done() and self._stderr_future.exception():
             # I'm not sure that this would ever not be done if it gets to this point
             # unless ffmpeg is doing something highly questionable
+            self.stop()
             self.emit('error', player=self, entry=entry, ex=self._stderr_future.exception())
+            return
 
         if not self.bot.config.save_videos and entry:
             if not isinstance(entry, StreamPlaylistEntry):
@@ -241,11 +248,8 @@ class MusicPlayer(EventEmitter, Serializable):
 
     def _kill_current_player(self):
         if self._current_player:
-            if self.voice_client.is_paused():
-                self.voice_client.resume()
-
             try:
-                self.voice_client.stop()
+                self._current_player.stop()
             except OSError:
                 pass
             self._current_player = None


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Prevent the player from playing after getting an error (in the very unlikely event that it happened). This prevents the player from potentially exhausting the playlist in the event that the problem would make all entries unplayable. The user may resume playing using the `resume` command if they deem that the error is not critical.


### Related issues (if applicable)

